### PR TITLE
Add missing cargo input

### DIFF
--- a/asahi/guix/packages/crates-io.scm
+++ b/asahi/guix/packages/crates-io.scm
@@ -22,7 +22,8 @@
      (build-system cargo-build-system)
      (arguments
       `(#:cargo-inputs
-        (("rust-bindgen" ,rust-bindgen-0.59))
+        (("rust-bindgen" ,rust-bindgen-0.59)
+         ("rust-env-logger" ,rust-env-logger-0.9))
         #:phases
         (modify-phases %standard-phases
           (add-before 'check 'disable-commandline-multiple-headers-test


### PR DESCRIPTION
This fixes the rust-bindgen-cli package so that it builds.